### PR TITLE
markers for applying interceptors

### DIFF
--- a/pytest_response/app.py
+++ b/pytest_response/app.py
@@ -75,7 +75,7 @@ class Response:
         self._db_path = self._basepath.joinpath(database)
         self.db = None
         self._path_to_mocks = self._basepath.joinpath(path)
-        self._available_mocks = list(self._get_available_mocks())
+        self._available_mocks = [x.name for x in self._get_available_mocks() if x.name != "__init__.py"]
         self._registered_mocks = {}
         self.mpatch = MonkeyPatch()
 


### PR DESCRIPTION
In certain cases, the interceptors are conflicting with each other, so I think its better every function has its separate interceptor.
This can be achieved by using pytest markers. Currently, the available markers are

- response_urllib
- response_urllib3
- response_requests
- respose_aiohttp
 